### PR TITLE
Nem dispatch period

### DIFF
--- a/electric_units/__init__.py
+++ b/electric_units/__init__.py
@@ -1,4 +1,5 @@
 """Package exports."""
 from electric_units.electrical_energy import ElectricalEnergy
 from electric_units.nem_settlement_period import NemSettlementPeriod
+from electric_units.nem_dispatch_period import NemDispatchPeriod
 from electric_units.watt_sample import WattSample

--- a/electric_units/nem_dispatch_period.py
+++ b/electric_units/nem_dispatch_period.py
@@ -31,7 +31,7 @@ class NemDispatchPeriod(BaseSettlementPeriod):
 
     @property
     def start(self):
-        """Rewind to the start of the half hour."""
+        """Rewind to the start of the 5-minute period."""
         moment = self.tz_match(self.moment)
 
         delta_to_start = timedelta(minutes=moment.minute % 5,

--- a/electric_units/nem_dispatch_period.py
+++ b/electric_units/nem_dispatch_period.py
@@ -34,7 +34,7 @@ class NemDispatchPeriod(BaseSettlementPeriod):
         """Rewind to the start of the 5-minute period."""
         moment = self.tz_match(self.moment)
 
-        delta_to_start = timedelta(minutes=moment.minute % 5,
+        delta_to_start = timedelta(minutes=moment.minute % self.freq_minutes,
                                    seconds=moment.second,
                                    microseconds=moment.microsecond)
 

--- a/electric_units/nem_dispatch_period.py
+++ b/electric_units/nem_dispatch_period.py
@@ -1,0 +1,74 @@
+"""A SettlementPeriod in the NEM region."""
+from datetime import timedelta
+from pytz import timezone
+from attr import attrs
+
+from electric_units.base_settlement_period import BaseSettlementPeriod
+
+
+@attrs(frozen=True)
+class NemDispatchPeriod(BaseSettlementPeriod):
+    """A NEM Dispatch Period.
+
+    The NEM is operated with 5-minute dispatch periods.
+    Instantiate one with a moment in time. This will assume this moment is
+    in AEST timezone, or, if a Timezone is present in the instantiating moment,
+    then it will be converted to AEST.
+
+    Args:
+        moment: A datetime, or None to use the current time.
+    """
+
+    @property
+    def freq_minutes(self):
+        """A dispatch period is 5 minutes long"""
+        return 5
+
+    @staticmethod
+    def time_zone():
+        """Australian Eastern Standard Time."""
+        return timezone('Etc/GMT-10')
+
+    @property
+    def start(self):
+        """Rewind to the start of the half hour."""
+        moment = self.tz_match(self.moment)
+
+        delta_to_start = timedelta(minutes=moment.minute % 5,
+                                   seconds=moment.second,
+                                   microseconds=moment.microsecond)
+
+        start = moment - delta_to_start
+        return start
+
+    def _period_id(self):
+        """An integer representing the dispatch period in the day.
+        Ranges from 1 to 288, and resets to 1 at 4:00AM AEST"""
+        hour = self.start.hour if self.start.hour < 4 else (self.start_hour - 4)
+        minute = self.start.minute
+
+        period_id = (12 * hour) + int(minute / 5) + 1
+
+        if self.start.hour < 4:
+            period_id += 20 * 12  # 20 hours from 4:00 to midnight
+
+        return period_id
+
+    @property
+    def dispatch_interval(self):
+        """A string representing the unique dispatch interval.
+        Takes the form of a zero-padded date string with a period ID at the end
+        Resets at 4:00AM AEST"""
+        start = self.start
+        start_date = start.date()
+
+        # add zero padding to make period_id 3 chars long
+        period_id = str(self.period_id).zfill(3)
+
+        if start.hour < 4 and period_id != "001":
+            start_date = start_date - timedelta(days=1)
+
+        # Concat zero-padded dates and add period id
+        dispatch_interval = "".join([start_date.strftime("%Y%m%d"), period_id])
+
+        return dispatch_interval

--- a/electric_units/nem_dispatch_period.py
+++ b/electric_units/nem_dispatch_period.py
@@ -56,9 +56,9 @@ class NemDispatchPeriod(BaseSettlementPeriod):
 
     @property
     def dispatch_interval(self):
-        """A string representing the unique dispatch interval.
-        Takes the form of a zero-padded date string with a period ID at the end
-        Resets at 4:00AM AEST"""
+        """String representing the unique interval, DISPATCHINTERVAL in the 
+        NEM data. Takes the form of a zero-padded date string with a 
+        period ID at the end. Each day starts at 4:00AM AEST"""
         start = self.start
         start_date = start.date()
 

--- a/electric_units/nem_dispatch_period.py
+++ b/electric_units/nem_dispatch_period.py
@@ -44,13 +44,13 @@ class NemDispatchPeriod(BaseSettlementPeriod):
     def _period_id(self):
         """An integer representing the dispatch period in the day.
         Ranges from 1 to 288, and resets to 1 at 4:00AM AEST"""
-        hour = self.start.hour if self.start.hour < 4 else (self.start_hour - 4)
+        if self.start.hour < 4:
+            hour = self.start.hour + 20 # 20 hours from 4:00 to midnight
+        else:
+            hour = self.start_hour - 4
         minute = self.start.minute
 
         period_id = (12 * hour) + int(minute / 5) + 1
-
-        if self.start.hour < 4:
-            period_id += 20 * 12  # 20 hours from 4:00 to midnight
 
         return period_id
 

--- a/tests/test_nem_dispatch_period.py
+++ b/tests/test_nem_dispatch_period.py
@@ -1,0 +1,49 @@
+"""Test the NemDispatchPeriod object. Assumes that the base object is the
+same as the NemSettlementPeriod object, so it doesn't require the same tests"""
+from datetime import datetime
+from pytz import timezone
+import pytest
+
+from electric_units import NemDispatchPeriod
+
+NEM_DATA = [
+    (
+        '2019-10-01T03:59:00',
+        timezone('Etc/GMT-10').localize(datetime(2019, 10, 1, 3, 55)),
+        288,
+        "20190930288"
+    ),
+    (
+        '2019-10-01T04:00:00',
+        timezone('Etc/GMT-10').localize(datetime(2019, 10, 1, 4, 0)),
+        1,
+        "20191001001"
+    ),
+    (
+        '2019-10-01T04:07:00',
+        timezone('Etc/GMT-10').localize(datetime(2019, 10, 1, 4, 5)),
+        2,
+        "20191001002"
+    ),
+    (
+        '2019-10-01T23:55:00',
+        timezone('Etc/GMT-10').localize(datetime(2019, 10, 1, 23, 55)),
+        240,
+        "20191001240"
+    ),
+    (
+        '2019-10-01T00:00:00',
+        timezone('Etc/GMT-10').localize(datetime(2019, 10, 1, 0, 0)),
+        241,
+        "20190930241"
+    ),
+]
+
+@pytest.mark.parametrize("moment, start, period_id, dispatch_interval", NEM_DATA)
+def test_nem_accuracy(moment, start, period_id, dispatch_interval):
+    """Test the correct NEM period is built."""
+    period = NemDispatchPeriod(moment)
+    assert period.start == start
+    assert period.period_id == period_id
+    assert period.dispatch_interval == dispatch_interval
+	


### PR DESCRIPTION
This adds a NemDispatchPeriod object which is a 5-minute period. The `period_id` attribute is a number from 1 to 288 on each day starting at 4:00 AEST. It also has the `dispatch_interval` property which uses the `period_id` at the end of a date string. 