### PR TITLE
Float conversion

### DIFF
--- a/electric_units/electrical_energy.py
+++ b/electric_units/electrical_energy.py
@@ -11,7 +11,7 @@ from electric_units.utils.datetime_coercion import datetime_coercion
 class ElectricalEnergy:
     """Energy used within a period of time."""
 
-    kwh = attrib(type=float)
+    kwh = attrib(type=float, converter=float)
     start = attrib(converter=datetime_coercion)
     end = attrib(converter=datetime_coercion)
     samples = attrib(type=list, eq=False, repr=False, default=None)

--- a/electric_units/watt_sample.py
+++ b/electric_units/watt_sample.py
@@ -13,7 +13,7 @@ class WattSample:
     drawn at a specific moment in time.
     """
 
-    watts = attrib(type=float)
+    watts = attrib(type=float, converter=float)
     moment = attrib(converter=datetime_coercion)
 
     def settlement_period(self, period_class):

--- a/tests/test_watt_sample.py
+++ b/tests/test_watt_sample.py
@@ -1,6 +1,7 @@
 """Test the WattSample object."""
 
 from datetime import datetime
+from decimal import Decimal
 from pytz import timezone
 import pytest
 
@@ -18,6 +19,9 @@ def test_can_create():
     sample_period = power_sample.settlement_period(NemSettlementPeriod)
     period = NemSettlementPeriod(moment=sample_time)
     assert sample_period == period
+
+    decimal_power_sample = WattSample(watts=Decimal(1000), moment=sample_time)
+    assert decimal_power_sample == power_sample
 
 
 def test_can_create_from_string():


### PR DESCRIPTION
Enforces conversion to `float` for `WattSample` and `ElectricalEnergy` objects. 